### PR TITLE
small fix start command for xmobar

### DIFF
--- a/lib/Workspaces.hs
+++ b/lib/Workspaces.hs
@@ -97,7 +97,7 @@ xmobarWorkspace conf fg bg prevws =
 
 myXmonadBar :: HC.HostConfiguration -> String
 myXmonadBar conf =
-        "xmobar .xmonad/" ++ barPrefix ++ "workspaces_xmobar.rc"
+        "xmobar ~/.xmonad/" ++ barPrefix ++ "workspaces_xmobar.rc"
         where barPrefix
                 | HC.isSlim conf   = "slim_"
                 | otherwise     = ""


### PR DESCRIPTION
there is a missing ~/ in path for config of xmobar. This small issue makes a problem when I start using a dynamicprojects with different workspaces direcotries.
Xmobar is complaining about missing .xmonad/*xmobar*.rc file. And after recompiling xmobar is gone.